### PR TITLE
Allow for removing approaches

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "defog-components",
-  "version": "0.49.32",
+  "version": "0.49.33",
   "description": "Front-end components for Defog",
   "author": "defog-ai",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "defog-components",
-  "version": "0.49.35",
+  "version": "0.49.36",
   "description": "Front-end components for Defog",
   "author": "defog-ai",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "defog-components",
-  "version": "0.49.33",
+  "version": "0.49.35",
   "description": "Front-end components for Defog",
   "author": "defog-ai",
   "license": "MIT",

--- a/src/components/agent/AgentMain.jsx
+++ b/src/components/agent/AgentMain.jsx
@@ -61,7 +61,7 @@ export default function AgentMain({ initialReportData, agentsEndpoint }) {
 
   function reInitSocket() {
     if (!socket.current || socket.current.readyState === WebSocket.CLOSED) {
-      return new Promise(function (resolve, reject) {
+      return new Promise(function (resolve) {
         socket.current = new WebSocket(agentsEndpoint);
         console.log("reconnecting..");
 
@@ -70,7 +70,7 @@ export default function AgentMain({ initialReportData, agentsEndpoint }) {
           setGlobalLoading(false);
           setStageDone(true);
           console.log("disconnected.");
-          const _ = await reInitSocket();
+          await reInitSocket();
         };
 
         socket.current.onopen = function () {
@@ -153,7 +153,7 @@ export default function AgentMain({ initialReportData, agentsEndpoint }) {
       const nextStage =
         agentRequestTypes[agentRequestTypes.indexOf(submitSourceStage) + 1];
 
-      const _ = await reInitSocket();
+      await reInitSocket();
 
       socket.current.send(
         JSON.stringify({
@@ -268,7 +268,7 @@ export default function AgentMain({ initialReportData, agentsEndpoint }) {
     if (typeof newSectionMarkdown !== "string") return;
 
     if (socket.current.readyState !== WebSocket.OPEN) {
-      const _ = await reInitSocket();
+      await reInitSocket();
     }
     try {
       const newReportSections = reportData.gen_report.report_sections.slice();

--- a/src/components/agent/AgentMain.jsx
+++ b/src/components/agent/AgentMain.jsx
@@ -262,12 +262,8 @@ export default function AgentMain({ initialReportData, agentsEndpoint }) {
   }
 
   async function updateReportText({ sectionNumber, newSectionMarkdown }) {
-    if (!sectionNumber) return;
     if (typeof newSectionMarkdown !== "string") return;
 
-    if (socket.current.readyState !== WebSocket.OPEN) {
-      await reInitSocket();
-    }
     try {
       console.log("updating report text");
       const newReportSections = reportData.gen_report.report_sections.slice();

--- a/src/components/agent/AgentMain.jsx
+++ b/src/components/agent/AgentMain.jsx
@@ -65,8 +65,7 @@ export default function AgentMain({ initialReportData, agentsEndpoint }) {
         socket.current = new WebSocket(agentsEndpoint);
         console.log("reconnecting..");
 
-        socket.current.onclose = async function (event) {
-          console.log(event);
+        socket.current.onclose = async function () {
           setGlobalLoading(false);
           setStageDone(true);
           console.log("disconnected.");
@@ -222,7 +221,6 @@ export default function AgentMain({ initialReportData, agentsEndpoint }) {
       return;
 
     console.log("updating approaches");
-    console.log(approach_idx, request_type, new_value);
     const newApproaches = reportData.gen_approaches.approaches.slice();
     const approachToUpdate = newApproaches[approach_idx];
     if (!approachToUpdate) return;
@@ -271,6 +269,7 @@ export default function AgentMain({ initialReportData, agentsEndpoint }) {
       await reInitSocket();
     }
     try {
+      console.log("updating report text");
       const newReportSections = reportData.gen_report.report_sections.slice();
       // find the section number and update the text
       const sectionToUpdate = newReportSections.find(
@@ -343,7 +342,7 @@ export default function AgentMain({ initialReportData, agentsEndpoint }) {
                 <ErrorBoundary>
                   <ReportDisplay
                     sections={reportData?.gen_report?.report_sections || []}
-                    updateReportText={updateReportText}
+                    handleEdit={handleEdit}
                     theme={theme}
                     loading={currentStage === "gen_report" ? !stageDone : false}
                     // only animate if this is new report text coming in

--- a/src/components/agent/AgentMain.jsx
+++ b/src/components/agent/AgentMain.jsx
@@ -213,15 +213,16 @@ export default function AgentMain({ initialReportData, agentsEndpoint }) {
   }
 
   async function updateApproaches({ approach_idx, request_type, new_value }) {
-    if (request_type !== "enable" && request_type !== "delete") return;
+    if (request_type !== "enabled" && request_type !== "delete") return;
     if (
-      !approach_idx ||
       typeof approach_idx !== "number" ||
       approach_idx > reportData.gen_approaches.approaches.length ||
       approach_idx < 0
     )
       return;
 
+    console.log("updating approaches");
+    console.log(approach_idx, request_type, new_value);
     const newApproaches = reportData.gen_approaches.approaches.slice();
     const approachToUpdate = newApproaches[approach_idx];
     if (!approachToUpdate) return;
@@ -237,9 +238,10 @@ export default function AgentMain({ initialReportData, agentsEndpoint }) {
         body: JSON.stringify({
           request_type: "edit_approaches",
           report_id: rId,
-          report_sections: newApproaches,
+          approaches: newApproaches,
         }),
       }).then((d) => d.json());
+
       if (!res.success) {
         message.error(
           "Something went wrong. Please try again or contact us if this persists.",

--- a/src/components/report-gen/Approaches.jsx
+++ b/src/components/report-gen/Approaches.jsx
@@ -92,9 +92,8 @@ export default function Approaches({
                           <div className="approach-toggle">
                             <Checkbox
                               checked={enabledApproaches[index]}
-                              onChange={(ev) => {
+                              onChange={() => {
                                 toggleEnable(index, !enabledApproaches[index]);
-                                console.log(ev);
                               }}
                             ></Checkbox>
                           </div>

--- a/src/components/report-gen/ReportGen.jsx
+++ b/src/components/report-gen/ReportGen.jsx
@@ -43,18 +43,22 @@ export default function ReportGen({
   handleSubmit = () => {},
   globalLoading,
   searchRef = null,
+  handleEdit = () => {},
 }) {
   const { theme } = useContext(ThemeContext);
   const carousel = useRef(null);
 
+  console.log(currentStage);
+
   useEffect(() => {
-    if (currentStage && currentStage !== "gen_report" && carousel.current) {
-      console.log(currentStage, generationStages.indexOf(currentStage));
-      carousel.current.goTo(generationStages.indexOf(currentStage));
-      // also scroll to top of screen
-      // window.scrollTo(0, 0);
+    if (currentStage && carousel.current) {
+      const idx = generationStages.indexOf(currentStage);
+      // if idx is -1, we're probably already generated a report. set to last (aka approaches)
+      carousel.current.goTo(idx > -1 ? idx : generationStages.length - 1);
+      // go to the top of the screen
+      window.scrollTo(0, 0);
     }
-  });
+  }, [currentStage]);
 
   return (
     <ReportGenWrap theme={theme}>
@@ -95,6 +99,7 @@ export default function ReportGen({
                         theme: theme,
                         globalLoading: globalLoading,
                         stageDone: stage === currentStage ? stageDone : true,
+                        handleEdit,
                       })
                     : null}
                 </div>

--- a/src/components/report/ReportDisplay.jsx
+++ b/src/components/report/ReportDisplay.jsx
@@ -1,5 +1,4 @@
 import React, { useEffect, Fragment, useState } from "react";
-import { createRoot } from "react-dom/client";
 import { marked } from "marked";
 import { csvTable, postprocess } from "../report-gen/marked-extensions";
 import { styled } from "styled-components";

--- a/src/components/report/ReportDisplay.jsx
+++ b/src/components/report/ReportDisplay.jsx
@@ -15,7 +15,7 @@ export function ReportDisplay({
   theme,
   loading,
   animate = false,
-  updateReportText = () => {},
+  handleEdit = () => {},
 }) {
   // marked lexer through each section, parse each of the generated tokens, and render it using the Writer
   // sort sections according to section number
@@ -107,7 +107,7 @@ export function ReportDisplay({
         "",
       );
       // send this to the backend with the section index
-      updateReportText(sectionNumber, newSectionMarkdown);
+      handleEdit("gen_report", { sectionNumber, newSectionMarkdown });
     } catch (e) {
       console.log(e);
     }


### PR DESCRIPTION
This PR adds the ability to remove approaches.
Here removal = "disabling". We still keep a record of the approach, but don't use it for report gen if it's disabled.

The user is free to come back and enable it again later and regenerate the report.