### PR TITLE
Additional information is now shown in debug mode, if returned from api endpoint

### DIFF
--- a/src/components/Answers.jsx
+++ b/src/components/Answers.jsx
@@ -62,6 +62,7 @@ const Answers = ({
         const {
           question,
           sql,
+          debugInfo,
           level,
           parentQuestionId,
           askedAt,
@@ -75,6 +76,7 @@ const Answers = ({
           questionId,
           question,
           generatedSql: sql,
+          debugInfo: debugInfo,
           level,
           parentQuestionId,
           askedAt,

--- a/src/components/DefogDynamicViz.jsx
+++ b/src/components/DefogDynamicViz.jsx
@@ -151,6 +151,15 @@ const DefogDynamicViz = ({
                   <pre style={{whiteSpace: "pre-wrap"}}>{response.generatedSql}</pre>
                 </>
               )}
+
+              {response.debugInfo && (
+                <>
+                  <hr/>
+                  <pre style={{whiteSpace: "pre-wrap"}}>
+                    {response.debugInfo}
+                  </pre>
+                </>
+              )}
             </SQLContainer>
 
             <FeedbackWrap theme={theme.config}>

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -252,6 +252,7 @@ export function AskDefogChat({
         analysis: queryChatResponse.analysis || null,
         visualization: queryChatResponse.visualization || "table",
         followUpQuestions: queryChatResponse.followUpQuestions || "",
+        debugInfo: queryChatResponse.debug_info || null,
       },
     };
 


### PR DESCRIPTION
If the API endpoint returns a JSON with the key `debug_info`, and if `debug` mode is active, users can now see additional debugging logs.

An example of this is below, from an endpoint that returned the query generation and execution time

![image](https://github.com/defog-ai/defog-components/assets/5008293/1318b42b-c60c-48c8-83d1-ab984a34d16c)
